### PR TITLE
minor modification in GetChannel exception throwing and hidden bug in Subscribe

### DIFF
--- a/src/Core/AppCore.Test/Messaging/MessageBusTest.cs
+++ b/src/Core/AppCore.Test/Messaging/MessageBusTest.cs
@@ -67,7 +67,20 @@ namespace RCd.AppCore.Test.Messaging
         }
 
         [Fact]
-        public void GetChannel_Throws_KeyNotFoundException_If_Channel_Is_Not_Registered()
+        public void GetChannel_Throws_ArgumentNullException_If_Channel_Is_Null_Or_Empty()
+        {
+            var mockMessageChannel = new Mock<IMessageChannel>();
+
+            IMessageChannel MessageBusFactory(string channelId) => mockMessageChannel.Object;
+
+            var messageBus = new MessageBus(MessageBusFactory);
+
+            Assert.Throws<ArgumentNullException>(() => messageBus.GetChannel(null));
+            Assert.Throws<ArgumentNullException>(() => messageBus.GetChannel(string.Empty));
+        }
+
+        [Fact]
+        public void GetChannel_Throws_ArgumentNullException_If_ChannelId_Is_Not_Registered()
         {
             const string notRegisteredChannelId = nameof(notRegisteredChannelId);
 
@@ -77,8 +90,6 @@ namespace RCd.AppCore.Test.Messaging
 
             var messageBus = new MessageBus(MessageBusFactory);
 
-            Assert.Throws<KeyNotFoundException>(() => messageBus.GetChannel(null));
-            Assert.Throws<KeyNotFoundException>(() => messageBus.GetChannel(string.Empty));
             Assert.Throws<KeyNotFoundException>(() => messageBus.GetChannel(notRegisteredChannelId));
         }
 

--- a/src/Core/AppCore/Messaging/MessageBus.cs
+++ b/src/Core/AppCore/Messaging/MessageBus.cs
@@ -45,7 +45,7 @@ namespace RCd.AppCore.Messaging
 
         public IMessageChannel GetChannel(string channelId)
         {
-            if (string.IsNullOrEmpty(channelId)) throw new KeyNotFoundException($"Channel not found: {channelId}");
+            if (string.IsNullOrEmpty(channelId)) throw new ArgumentNullException(nameof(channelId));
             return _channels[channelId];
         }
 

--- a/src/Core/AppCore/Messaging/MessageChannel.cs
+++ b/src/Core/AppCore/Messaging/MessageChannel.cs
@@ -51,7 +51,7 @@ namespace RCd.AppCore.Messaging
                 _subscribers[messageType] = new List<ISubscriber>();
             }
 
-            _subscribers[typeof(TMessage)].Add(subscriber);
+            _subscribers[messageType].Add(subscriber);
 
             return subscriber;
         }


### PR DESCRIPTION
- throw ArgumentNullException in GetChannel when channelId is null or… empty to stay clean with channelId check in RegisterChannel
- MessageChannel Subscribe used different keys to access _subscribers dictionary which leads to a bug when GetMessageType returns other type than typeof(TMessage) in future versions